### PR TITLE
Populate repo

### DIFF
--- a/.github/workflows/unit_testing.yaml
+++ b/.github/workflows/unit_testing.yaml
@@ -1,0 +1,31 @@
+name: CMake
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      run: >
+        cmake
+        -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DCMAKE_CXX_STANDARD=17
+        -DBUILD_TESTING=TRUE
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# CMake ignores
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+# Build/installation ignores
+build/
+install/
+lib*/
+bin/
+share/
+staging/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(CMaizePublicDepend2 VERSION 1.0.0 LANGUAGES CXX)
+
+set(
+    CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake"
+    CACHE STRING "" FORCE
+)
+
+include(get_cmaize)
+
+# Get dependencies
+cpp_find_or_build_dependency(
+    CMaizePublicDepend
+    URL github.com/CMaizeExamples/CMaizePublicDepend
+    BUILD_TARGET CMaizePublicDepend
+    FIND_TARGET CMaizePublicDepend::CMaizePublicDepend
+)
+
+# Build the library
+cmaize_add_library(
+    ${PROJECT_NAME}
+    INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/include/cmaize_public_depend_2"
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/src/cmaize_public_depend_2"
+    DEPENDS CMaizePublicDepend::CMaizePublicDepend
+)
+
+# Build tests
+cpp_find_or_build_dependency(
+    Catch2
+    URL github.com/catchorg/Catch2
+    BUILD_TARGET Catch2
+    FIND_TARGET Catch2::Catch2WithMain
+    VERSION v3.0.1
+)
+
+cmaize_add_tests(
+    test_${PROJECT_NAME}
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test/cmaize_public_depend_2"
+    INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/src/cmaize_public_depend_2"
+    DEPENDS Catch2::Catch2WithMain ${PROJECT_NAME}
+)
+
+# Install the package
+cmaize_add_package(${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ cpp_find_or_build_dependency(
     URL github.com/CMaizeExamples/CMaizePublicDepend
     BUILD_TARGET CMaizePublicDepend
     FIND_TARGET CMaizePublicDepend::CMaizePublicDepend
+    CMAKE_ARGS BUILD_TESTING=FALSE
 )
 
 # Build the library
@@ -25,21 +26,23 @@ cmaize_add_library(
     DEPENDS CMaizePublicDepend::CMaizePublicDepend
 )
 
-# Build tests
-cpp_find_or_build_dependency(
-    Catch2
-    URL github.com/catchorg/Catch2
-    BUILD_TARGET Catch2
-    FIND_TARGET Catch2::Catch2WithMain
-    VERSION v3.0.1
-)
+if (BUILD_TESTING)
+    # Build tests
+    cpp_find_or_build_dependency(
+        Catch2
+        URL github.com/catchorg/Catch2
+        BUILD_TARGET Catch2
+        FIND_TARGET Catch2::Catch2WithMain
+        VERSION v3.0.1
+    )
 
-cmaize_add_tests(
-    test_${PROJECT_NAME}
-    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test/cmaize_public_depend_2"
-    INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/src/cmaize_public_depend_2"
-    DEPENDS Catch2::Catch2WithMain ${PROJECT_NAME}
-)
+    cmaize_add_tests(
+        test_${PROJECT_NAME}
+        SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test/cmaize_public_depend_2"
+        INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/src/cmaize_public_depend_2"
+        DEPENDS Catch2::Catch2WithMain ${PROJECT_NAME}
+    )
+endif()
 
 # Install the package
 cmaize_add_package(${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # CMaizePublicDepend2
-A public GitHub repo that contains a C++ library. The library should define a function call_cmake_public_depend2 which calls call_cmake_public_depend and should depend on CMaizePublicDepend.
+
+A public GitHub repo that contains a C++ library. The library should define a
+function `call_cmake_public_depend2()` which calls
+`call_cmake_public_depend()` and should depend on `CMaizePublicDepend`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CMaizePublicDepend2
 
 A public GitHub repo that contains a C++ library. The library should define a
-function `call_cmake_public_depend_2()` which calls
-`call_cmake_public_depend()` and should depend on `CMaizePublicDepend`.
+function `call_cmaize_public_depend_2()` which calls
+`call_cmaize_public_depend()` and should depend on `CMaizePublicDepend`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CMaizePublicDepend2
 
 A public GitHub repo that contains a C++ library. The library should define a
-function `call_cmake_public_depend2()` which calls
+function `call_cmake_public_depend_2()` which calls
 `call_cmake_public_depend()` and should depend on `CMaizePublicDepend`.

--- a/cmake/get_cmaize.cmake
+++ b/cmake/get_cmaize.cmake
@@ -1,0 +1,31 @@
+#[[
+# This function encapsulates the process of getting CMakePP using CMake's
+# FetchContent module. We have encapsulated it in a function so we can set
+# the options for its configure step without affecting the options for the
+# parent project's configure step (namely we do not want to build CMakePP's
+# unit tests).
+#]]
+function(get_cmaize)
+
+    # Store whether we are building tests or not, then turn off the tests
+    set(build_testing_old "${BUILD_TESTING}")
+    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+
+    # Download CMakePP and bring it into scope
+    include(FetchContent)
+    FetchContent_Declare(
+         cmaize
+         GIT_REPOSITORY https://github.com/CMakePP/CMakePackagingProject
+    )
+    FetchContent_MakeAvailable(cmaize)
+
+    # Restore the previous value
+    set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)
+endfunction()
+
+# Call the function we just wrote to get CMakePP
+get_cmaize()
+
+# Include CMaize
+include(cpp/cpp)
+include(cmaize/cmaize)

--- a/cmake/get_cmaize.cmake
+++ b/cmake/get_cmaize.cmake
@@ -14,8 +14,8 @@ function(get_cmaize)
     # Download CMakePP and bring it into scope
     include(FetchContent)
     FetchContent_Declare(
-         cmaize
-         GIT_REPOSITORY https://github.com/CMakePP/CMakePackagingProject
+        cmaize
+        GIT_REPOSITORY https://github.com/CMakePP/CMakePackagingProject
     )
     FetchContent_MakeAvailable(cmaize)
 

--- a/include/cmaize_public_depend_2/cmaize_public_depend_2.hpp
+++ b/include/cmaize_public_depend_2/cmaize_public_depend_2.hpp
@@ -1,6 +1,5 @@
-#ifndef __CMAIZE_PUBLIC_DEPEND_2
-#define __CMAIZE_PUBLIC_DEPEND_2
+#pragma once
 
 #include <cmaize_public_depend/cmaize_public_depend.hpp>
 
-#endif // __CMAIZE_PUBLIC_DEPEND_2
+int call_cmaize_public_depend_2();

--- a/include/cmaize_public_depend_2/cmaize_public_depend_2.hpp
+++ b/include/cmaize_public_depend_2/cmaize_public_depend_2.hpp
@@ -1,0 +1,6 @@
+#ifndef __CMAIZE_PUBLIC_DEPEND_2
+#define __CMAIZE_PUBLIC_DEPEND_2
+
+#include <cmaize_public_depend/cmaize_public_depend.hpp>
+
+#endif // __CMAIZE_PUBLIC_DEPEND_2

--- a/src/cmaize_public_depend_2/cmaize_public_depend_2.cpp
+++ b/src/cmaize_public_depend_2/cmaize_public_depend_2.cpp
@@ -1,5 +1,5 @@
 #include "cmaize_public_depend_2/cmaize_public_depend_2.hpp"
 
-int call_cmake_public_depend_2() {
-    return call_cmake_public_depend() + 2;
+int call_cmaize_public_depend_2() {
+    return call_cmaize_public_depend() + 2;
 }

--- a/src/cmaize_public_depend_2/cmaize_public_depend_2.cpp
+++ b/src/cmaize_public_depend_2/cmaize_public_depend_2.cpp
@@ -1,0 +1,5 @@
+#include "cmaize_public_depend_2/cmaize_public_depend_2.hpp"
+
+int call_cmake_public_depend2() {
+    return call_cmake_public_depend() + 2;
+}

--- a/src/cmaize_public_depend_2/cmaize_public_depend_2.cpp
+++ b/src/cmaize_public_depend_2/cmaize_public_depend_2.cpp
@@ -1,5 +1,5 @@
 #include "cmaize_public_depend_2/cmaize_public_depend_2.hpp"
 
-int call_cmake_public_depend2() {
+int call_cmake_public_depend_2() {
     return call_cmake_public_depend() + 2;
 }

--- a/test/cmaize_public_depend_2/test_cmaize_public_depend_2.cpp
+++ b/test/cmaize_public_depend_2/test_cmaize_public_depend_2.cpp
@@ -1,0 +1,9 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmaize_public_depend_2/cmaize_public_depend_2.hpp>
+
+TEST_CASE("cmaize_public_depend_2") {
+    SECTION("does_cmaize_public_depend_2_work") {
+        REQUIRE(call_cmaize_public_depend_2() == 7);
+    }
+}


### PR DESCRIPTION
This PR sets up the repository with everything it needs to run. This was essentially just CMaizePublicDepend copied over and changed to make CMaizePublicDepend2

Similar to CMaizePublicDepend, this is slightly different in implementation than the PR from two years ago. Primarily, the C++ code is laid out into `src` and `include` directories and the `CMakeLists.txt` file was rewritten to use the current API of CMaize.

## Todo
- [x] Add a basic `.gitignore`.
- [x] Add a `cmake/get_cmaize.cmake` file.
- [x] Write the headers and source for the library, described in `README.md`.
- [x] Create a `CMakeLists.txt` to build the library.
- [x] Create basic unit tests to make sure the code compiles.
- [x] Set up CI to run unit testing (this will be slightly expanded later for integration testing, but we just need to know that the code I wrote works for now)