### PR TITLE
Bump Catch2 3.0.1 -> 3.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if (BUILD_TESTING)
         URL github.com/catchorg/Catch2
         BUILD_TARGET Catch2
         FIND_TARGET Catch2::Catch2WithMain
-        VERSION v3.0.1
+        VERSION v3.4.0
     )
 
     cmaize_add_tests(


### PR DESCRIPTION
The Catch2 version needed to be updated to work with gcc 13.